### PR TITLE
Replaced close() to quit() in tearDown()

### DIFF
--- a/tests/GitHubTest.php
+++ b/tests/GitHubTest.php
@@ -19,7 +19,7 @@ class GitHubTest extends PHPUnit_Framework_TestCase {
 
     public function tearDown()
     {
-        $this->webDriver->close();
+        $this->webDriver->quit();
     }
 
     public function testGitHubHome()


### PR DESCRIPTION
Hello, I started using WebDriver from your example and was confused about that Selenium don't delete profiles from temp directory. Please, correct example, facebook/php-webdriver [reference to you](https://github.com/facebook/php-webdriver#more-information)
